### PR TITLE
Improved response error handling

### DIFF
--- a/pyasassn/client.py
+++ b/pyasassn/client.py
@@ -67,10 +67,9 @@ class SkyPatrolClient:
         response = requests.post(url, json={'format': 'arrow',
                                             'download': download})
 
-        # Check response
-        if response.status_code == 400:
-            error = json.loads(response.content)['error_text']
-            raise RuntimeError(error)
+        # if the status code is not an error code (4xx or 5xx), it is considered ‘true’
+        if not response:
+            response.raise_for_status()
 
         # Deserialize from arrow
         tar_df = _deserialize(response)

--- a/pyasassn/client.py
+++ b/pyasassn/client.py
@@ -68,8 +68,7 @@ class SkyPatrolClient:
                                             'download': download})
 
         # if the status code is not an error code (4xx or 5xx), it is considered ‘true’
-        if not response:
-            response.raise_for_status()
+        self._validate_response(response)
 
         # Deserialize from arrow
         tar_df = _deserialize(response)
@@ -135,9 +134,7 @@ class SkyPatrolClient:
                                             'download': download})
 
         # Check response
-        if response.status_code == 400:
-            error = json.loads(response.content)['error_text']
-            raise RuntimeError(error)
+        self._validate_response(response)
 
         # Deserialize from arrow
         tar_df = _deserialize(response)
@@ -219,9 +216,7 @@ class SkyPatrolClient:
                                             'download': download})
 
         # Check response
-        if response.status_code == 400:
-            error = json.loads(response.content)['error_text']
-            raise RuntimeError(error)
+        self._validate_response(response)
 
         # Deserialize from arrow
         tar_df = _deserialize(response)
@@ -289,9 +284,7 @@ class SkyPatrolClient:
                                             'download': download})
 
         # Check response
-        if response.status_code == 400:
-            error = json.loads(response.content)['error_text']
-            raise RuntimeError(error)
+        self._validate_response(response)
 
         # Deserialize from arrow
         tar_df = _deserialize(response)
@@ -342,6 +335,14 @@ class SkyPatrolClient:
         # Return as dataframe
         return _deserialize(response)
 
+    def _validate_response(self, response):
+        """
+        Validate the response before deserialization
+        """
+        # If the response is not an error (4xx, 5xx), it is true
+        if not response:
+            response.raise_for_status()
+
 
     class InputCatalogs(object):
         """
@@ -387,7 +388,6 @@ class SkyPatrolClient:
 
         def __getitem__(self, item):
             return self.__dict__[item]
-
 
 def _deserialize(response):
     # Deserialize from arrow


### PR DESCRIPTION
Currently getting error 500 requests when running ADQL queries. There's no code to support this so pyarrow is trying to deserialise it and failing without giving useful information. Here's a tiny fix that will catch all 4xx/5xx errors in the future.